### PR TITLE
Migrating to Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OutReach by team26
 
-Website Link: https://outreachapp.herokuapp.com/
+Website Link: https://outreach.onrender.com/
 
 ## Non-Logged Users
 On launch, you are able to browse messages by navigating to city pages using the pins on the world map.  

--- a/db/mongoose.js
+++ b/db/mongoose.js
@@ -2,6 +2,6 @@
 
 const mongoose = require('mongoose');
 
-mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/OutreachAPI', { useNewUrlParser: true, useCreateIndex: true, useUnifiedTopology: true});
+mongoose.connect(encodeURI(process.env.MONGODB_URI) || 'mongodb://localhost:27017/OutreachAPI', { useNewUrlParser: true, useCreateIndex: true, useUnifiedTopology: true});
 
 module.exports = { mongoose }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "version": "1.0.0",
     "description": "",
     "main": "server.js",
+    "engines": {
+        "node": "16.18.1"
+      },
     "scripts": {
         "setup": "npm install && cd client && npm install && cd ..",
         "build-run": "cd client && npm run build && cd .. && node server.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
         "setup": "npm install && cd client && npm install && cd ..",
         "build-run": "cd client && npm run build && cd .. && node server.js",
         "start": "node server.js",
-        "heroku-postbuild": "cd client && npm install && npm run build",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "author": "",


### PR DESCRIPTION
- Create new Render account and setup web service
- Force usage of node v16 to build the app (fixes deployment failure bug)
- Encode mongodb uri to support Render environment variable